### PR TITLE
Update role: ansible-awx

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,32 @@
+---
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,54 @@
+# AGENTS.md
+
+This file provides guidance to AI coding agents when working with code in this repository.
+
+## Overview
+
+Vagrant lab + Ansible playbooks for deploying [Ansible AWX](https://github.com/ansible/awx) (open-source Ansible Tower) on Ubuntu 16.04. Spins up two VirtualBox VMs and provisions them with Ansible, Docker, and AWX.
+
+No Molecule tests — this is a standalone lab, not an Ansible role.
+
+## Lab Setup
+
+```bash
+vagrant up                          # start both VMs
+vagrant ssh ansible-awx             # SSH into the AWX host
+vagrant status                      # check VM state
+```
+
+| VM | IP | Purpose |
+|---|---|---|
+| `ansible-awx` | `192.168.33.11` | Hosts AWX |
+| `ansible-lab` | `192.168.33.12` | Test target |
+
+## Playbooks
+
+Run individually with `-l ansible-awx` to target the AWX host, or omit to run against all:
+
+```bash
+# Install Ansible 2.4+ via PPA
+ansible-playbook -i inventory.ini -l ansible-awx install_ansible.yml
+
+# Install Docker + pip + docker-py
+ansible-playbook -i inventory.ini -l ansible-awx install_docker.yml
+
+# Clone ansible/awx and run its installer (skips if port 80 already responds 200)
+ansible-playbook -i inventory.ini -l ansible-awx install_awx.yml
+
+# Run all three in sequence
+ansible-playbook -i inventory.ini playbook.yml
+```
+
+AWX UI: `http://192.168.33.11` — default credentials: `admin` / `password`
+
+## Linting
+
+```bash
+yamllint .
+```
+
+## Notes
+
+- Targets Ubuntu 16.04 / Docker Engine (not Docker CE) — these are old but intentional for the lab
+- `install_docker.yml` uses the legacy `apt.dockerproject.org` repo — update if targeting a newer Ubuntu
+- `install_awx.yml` checks port 80 before running the AWX installer to avoid reinstalling

--- a/install_awx.yml
+++ b/install_awx.yml
@@ -14,16 +14,15 @@
     ignore_errors: true
     uri:
       url: http://localhost:80
-    register: localhost
+    register: awx_check
 
   - name: output status code
     debug:
-      var: localhost.status
+      var: awx_check.status
 
   - name: Install and run AWX if it's not already running on port 80
     command: ansible-playbook -i inventory install.yml
     args:
       chdir: /opt/awx/installer/
     when:
-      - localhost is defined
-      - localhost.status != 200
+      - awx_check.status is not defined or awx_check.status != 200


### PR DESCRIPTION
## Summary
- Fixes `register: localhost` in `install_awx.yml` — shadowed Ansible's built-in `localhost` host and made the `when` condition always pass even on errors
- Adds standard `.yamllint` config
- Adds `AGENTS.md`

## Test plan
- [ ] `yamllint .` passes ✅ (verified locally)
- [ ] Vagrant lab not tested (requires VirtualBox + Ubuntu 16.04 box)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)